### PR TITLE
Changed loop to run until process turns zombie.

### DIFF
--- a/memplot/memplot.py
+++ b/memplot/memplot.py
@@ -15,15 +15,12 @@ def memplot(cmd,wait_time=0.05):
     usage = []
     p = subprocess.Popen(cmd,shell=True)
     util_process = psutil.Process(p.pid)
-    while True:
-        try:
-            stats = util_process.memory_info()
-            usage.append((datetime.now(),
-                          stats.rss,
-                          stats.vms,))
-            sleep(wait_time)
-        except:
-            break
+    while util_process.status() != psutil.STATUS_ZOMBIE:
+        stats = util_process.memory_info()
+        usage.append((datetime.now(),
+                      stats.rss,
+                      stats.vms,))
+        sleep(wait_time)
 
     t,rss,vms = zip(*usage)
 


### PR DESCRIPTION
The loop earlier used to run indefinitely and could be halted only by raising a KeyboardInterrupt. This loop is halted as soon as the subprocess finishes execution and turns into a zombie.
